### PR TITLE
fix: manage error when plugin is loaded

### DIFF
--- a/src/Lib/Lionk.Plugin.Blazor/PluginCard.razor
+++ b/src/Lib/Lionk.Plugin.Blazor/PluginCard.razor
@@ -14,12 +14,23 @@ else
 {
     <MudCard Class="floating-card" Outlined="true">
         <MudCardHeader>
-            <div>
+            <div style="display: flex; align-items: center; justify-content: space-between;">
+                <div>
                 <MudText Typo="Typo.h6">@Plugin.Name</MudText>
                 <MudText Typo="Typo.subtitle2">@Plugin.Version</MudText>
+                </div>
             </div>
         </MudCardHeader>
         <MudCardContent>
+            @if (!Plugin.IsLoaded)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Error" Color="Color.Error" Style="cursor: pointer;">
+                    <MudTooltip Text="Plugin is not loaded. Hover to see error message.">
+                        <MudIconButton Icon="@Icons.Material.Filled.Info" Color="Color.Error" />
+                    </MudTooltip>
+                </MudIconButton>
+            }
+
             <MudText Typo="Typo.body1">@Plugin.Description</MudText>
             <MudText Typo="Typo.body2">Author: @Plugin.Author</MudText>
 
@@ -30,6 +41,7 @@ else
                     {
                         <MudListItem>@dependency</MudListItem>
                     }
+                }
                 </MudList>
             </MudCollapse>
         </MudCardContent>

--- a/src/Lib/Lionk.Plugin.Blazor/PluginCard.razor
+++ b/src/Lib/Lionk.Plugin.Blazor/PluginCard.razor
@@ -16,19 +16,21 @@ else
         <MudCardHeader>
             <div style="display: flex; align-items: center; justify-content: space-between;">
                 <div>
-                <MudText Typo="Typo.h6">@Plugin.Name</MudText>
-                <MudText Typo="Typo.subtitle2">@Plugin.Version</MudText>
+                    <MudText Typo="Typo.h6">@Plugin.Name</MudText>
+                    <MudText Typo="Typo.subtitle2">@Plugin.Version</MudText>
                 </div>
             </div>
         </MudCardHeader>
         <MudCardContent>
             @if (!Plugin.IsLoaded)
             {
-                <MudIconButton Icon="@Icons.Material.Filled.Error" Color="Color.Error" Style="cursor: pointer;">
-                    <MudTooltip Text="Plugin is not loaded. Hover to see error message.">
-                        <MudIconButton Icon="@Icons.Material.Filled.Info" Color="Color.Error" />
-                    </MudTooltip>
-                </MudIconButton>
+                <MudTooltip Text="Something went wrong during plugin loading, you must delete and readd your plugin.">
+                    <MudIconButton
+                        Icon="@Icons.Material.Filled.Error"
+                        Color="Color.Error"
+                        Style="cursor: pointer;">
+                    </MudIconButton>
+                </MudTooltip>
             }
 
             <MudText Typo="Typo.body1">@Plugin.Description</MudText>
@@ -41,7 +43,7 @@ else
                     {
                         <MudListItem>@dependency</MudListItem>
                     }
-                }
+                    }
                 </MudList>
             </MudCollapse>
         </MudCardContent>

--- a/src/Lib/Lionk.Plugin/Model/Plugin.cs
+++ b/src/Lib/Lionk.Plugin/Model/Plugin.cs
@@ -54,6 +54,11 @@ public class Plugin
     /// </summary>
     public string[] Dependencies { get; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the plugin has been correctly loaded.
+    /// </summary>
+    public bool IsLoaded { get; set; }
+
     private T? GetAttribute<T>(Assembly assembly)
         where T : Attribute
     {

--- a/src/Lib/Lionk.Plugin/Model/PluginManager.cs
+++ b/src/Lib/Lionk.Plugin/Model/PluginManager.cs
@@ -70,7 +70,18 @@ public class PluginManager : IPluginManager
         var types = new List<Type>();
 
         foreach (Plugin plugin in _plugins)
-            types.AddRange(plugin.Assembly.GetTypes());
+        {
+            try
+            {
+                types.AddRange(plugin.Assembly.GetTypes());
+                plugin.IsLoaded = true;
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                plugin.IsLoaded = false;
+                LogService.LogApp(LogSeverity.Error, $"Failed to load types from plugin: {plugin.Name}. Error: {e.Message}");
+            }
+        }
 
         return types;
     }


### PR DESCRIPTION
Add a fix to show an icon when the plugin is not corectly loaded and catch an exception who can be throw when a type doesn't exist anymore.