### PR TITLE
feat: abstract measurable component from is generic type

### DIFF
--- a/src/Lib/Lionk.Core/Model/Component/Interface/IMeasurableComponent.cs
+++ b/src/Lib/Lionk.Core/Model/Component/Interface/IMeasurableComponent.cs
@@ -10,6 +10,15 @@ namespace Lionk.Core.Component;
 /// <typeparam name="T"> The type of the value. </typeparam>
 public interface IMeasurableComponent<T> : IComponent, IMeasurable
 {
+    #region delegate and events
+
+    /// <summary>
+    ///     Raised when a new value is available.
+    /// </summary>
+    event EventHandler<MeasureEventArgs<T>>? NewValueAvailable;
+
+    #endregion
+
 
     #region properties
 
@@ -27,14 +36,6 @@ public interface IMeasurableComponent<T> : IComponent, IMeasurable
 /// </summary>
 public interface IMeasurable
 {
-    #region delegate and events
-
-    /// <summary>
-    ///     Raised when a new value is available.
-    /// </summary>
-    event EventHandler<MeasureEventArgs<T>>? NewValueAvailable;
-
-    #endregion
 
     #region public and override methods
 

--- a/src/Lib/Lionk.Core/Model/Component/Interface/IMeasurableComponent.cs
+++ b/src/Lib/Lionk.Core/Model/Component/Interface/IMeasurableComponent.cs
@@ -10,14 +10,6 @@ namespace Lionk.Core.Component;
 /// <typeparam name="T"> The type of the value. </typeparam>
 public interface IMeasurableComponent<T> : IComponent, IMeasurable
 {
-    #region delegate and events
-
-    /// <summary>
-    ///     Raised when a new value is available.
-    /// </summary>
-    event EventHandler<MeasureEventArgs<T>>? NewValueAvailable;
-
-    #endregion
 
     #region properties
 
@@ -25,6 +17,22 @@ public interface IMeasurableComponent<T> : IComponent, IMeasurable
     ///     Gets the measures of the component.
     /// </summary>
     List<Measure<T>> Measures { get; }
+
+    #endregion
+
+}
+
+/// <summary>
+/// This interface defines a measurable component without a type.
+/// </summary>
+public interface IMeasurable
+{
+    #region delegate and events
+
+    /// <summary>
+    ///     Raised when a new value is available.
+    /// </summary>
+    event EventHandler<MeasureEventArgs<T>>? NewValueAvailable;
 
     #endregion
 
@@ -36,8 +44,4 @@ public interface IMeasurableComponent<T> : IComponent, IMeasurable
     void Measure();
 
     #endregion
-}
-
-public interface IMeasurable
-{
 }

--- a/src/Lib/Lionk.Core/Model/Component/Interface/IMeasurableComponent.cs
+++ b/src/Lib/Lionk.Core/Model/Component/Interface/IMeasurableComponent.cs
@@ -8,7 +8,7 @@ namespace Lionk.Core.Component;
 ///     This interface defines a measurable component.
 /// </summary>
 /// <typeparam name="T"> The type of the value. </typeparam>
-public interface IMeasurableComponent<T> : IComponent
+public interface IMeasurableComponent<T> : IComponent, IMeasurable
 {
     #region delegate and events
 
@@ -36,4 +36,8 @@ public interface IMeasurableComponent<T> : IComponent
     void Measure();
 
     #endregion
+}
+
+public interface IMeasurable
+{
 }


### PR DESCRIPTION
This feature improves the ability of views to identify a component as a measurable component by creating a simple `IMeasurable`

Now we can use this new interface in `ViewOfAttribute`.
exemple:
```c#
@attribute [ViewOfAttribute("Time series widget for measurable components", typeof(IMeasurable), typeof(TimeSeriesComponent), ViewContext.Widget)]
```